### PR TITLE
Added HelpArticle for AuthorsRoles

### DIFF
--- a/assets/inapp.json
+++ b/assets/inapp.json
@@ -250,5 +250,9 @@
   "FormEditor_limited": {
     "name": "FormEditor limited editing",
     "description": "Submissions have been recieved for this form, you can only change the labels of the fields and static text"
+  },
+  "AuthorRoles": {
+    "name": "Print author roles",
+    "description": "Checking this causes primary authors to be printed with an asterisk(*)"
   }
 }


### PR DESCRIPTION
Added help article for the checkbox to add or remove the asterisk(*) from primary authors.

Related PR-s:

- web https://github.com/slayte/web/pull/964
- app https://github.com/slayte/app/pull/679


Asana Ticket: https://app.asana.com/0/602047790487914/977820544107327/f