### PR TITLE
added Subscribe calendar Article

### DIFF
--- a/assets/inapp.json
+++ b/assets/inapp.json
@@ -254,5 +254,9 @@
   "AuthorRoles": {
     "name": "Print author roles",
     "description": "Checking this causes primary authors to be printed with an asterisk(*)"
+  },
+  "SubscribeCalendar": {
+    "name": "How to subscribe to your appointments ",
+    "description": "On this tab you can additionally export your appointment data into an external calendar e.g. Google/Outlook Calendar or even on your phone. To do this:\n\n\nOn the top-left corner of this page click Subscribe Calendar.\nCopy the URL link displayed.\nIn an external calendar of your choice (e.g. Google Calendar) find the option to Add a New Calendar using URL.\nPaste your copied URL from Slayte into this space provided to paste a new calendar URL.\nSave changes."
   }
 }


### PR DESCRIPTION
Added article to explain how a user can subscribe to their appointments calendar.

Related PR-s:

- web https://github.com/slayte/web/pull/936
- app https://github.com/slayte/app/pull/654
- app https://github.com/slayte/app/pull/694 NEW
- machine https://github.com/slayte/machine/pull/312
- enum https://github.com/slayte/enum/pull/146

Asana Ticket: https://app.asana.com/0/257155481354233/977688362504481/f